### PR TITLE
Fixed typo in name of WaterML 1.1 format.

### DIFF
--- a/objectFormatListV2.xml
+++ b/objectFormatListV2.xml
@@ -126,7 +126,7 @@
     </objectFormat>
     <objectFormat>
         <formatId>http://www.cuahsi.org/waterML/1.1/</formatId>
-        <formatName>Water Markup Language, version 1.0</formatName>
+        <formatName>Water Markup Language, version 1.1</formatName>
         <formatType>METADATA</formatType>
         <mediaType name="text/xml"/>
         <extension>xml</extension>

--- a/objectFormatListV2.xml
+++ b/objectFormatListV2.xml
@@ -120,14 +120,14 @@
     <objectFormat>
         <formatId>http://www.cuahsi.org/waterML/1.0/</formatId>
         <formatName>Water Markup Language, version 1.0</formatName>
-        <formatType>METADATA</formatType>
+        <formatType>DATA</formatType>
         <mediaType name="text/xml"/>
         <extension>xml</extension>
     </objectFormat>
     <objectFormat>
         <formatId>http://www.cuahsi.org/waterML/1.1/</formatId>
         <formatName>Water Markup Language, version 1.1</formatName>
-        <formatType>METADATA</formatType>
+        <formatType>DATA</formatType>
         <mediaType name="text/xml"/>
         <extension>xml</extension>
     </objectFormat>


### PR DESCRIPTION
Partial fix for issue #6.